### PR TITLE
fix(Supplier Quotation Comparison): add a missing translate function

### DIFF
--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
@@ -284,15 +284,15 @@ def get_columns(filters):
 
 
 def get_message():
-	return """<span class="indicator">
-		Valid till : &nbsp;&nbsp;
+	return f"""<span class="indicator">
+		{_("Valid till :")} &nbsp;&nbsp;
 		</span>
 		<span class="indicator orange">
-		Expires in a week or less
+		{_("Expires in a week or less")}
 		</span>
 		&nbsp;&nbsp;
 		<span class="indicator red">
-		Expires today / Already Expired
+		{_("Expires today / Already Expired")}
 		</span>"""
 
 

--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
@@ -285,14 +285,14 @@ def get_columns(filters):
 
 def get_message():
 	return f"""<span class="indicator">
-		{_("Valid till :")} &nbsp;&nbsp;
+		{_("Valid Till")}:&nbsp;&nbsp;
 		</span>
 		<span class="indicator orange">
 		{_("Expires in a week or less")}
 		</span>
 		&nbsp;&nbsp;
 		<span class="indicator red">
-		{_("Expires today / Already Expired")}
+		{_("Expires today or already expired")}
 		</span>"""
 
 


### PR DESCRIPTION
in **Report** `Supplier Quotation Comparison`

### Before
<img width="2241" height="275" alt="Before" src="https://github.com/user-attachments/assets/d65ea729-009e-4af8-b501-ef72233b4ed6" />


### After
<img width="2282" height="265" alt="After" src="https://github.com/user-attachments/assets/429b2bf4-c84a-4fcc-9538-9c8c00004a60" />

backport version-15-hotfix
