### PR TITLE
fix: add missing translate function

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -198,7 +198,7 @@ frappe.ui.form.on("Asset", {
 					callback: function (r) {
 						if (!r.message) {
 							$(".primary-action").prop("hidden", true);
-							$(".form-message").text("Capitalize this asset to confirm");
+							$(".form-message").text(__("Capitalize this asset to confirm"));
 
 							frm.add_custom_button(__("Capitalize Asset"), function () {
 								frm.trigger("create_asset_capitalization");


### PR DESCRIPTION
### Before
<img width="1868" height="724" alt="image" src="https://github.com/user-attachments/assets/dbba96f2-de51-4cb2-8a48-b485e12e9793" />

### After
<img width="1872" height="749" alt="image" src="https://github.com/user-attachments/assets/e87bf0f7-eed4-493d-8621-ac5b1522376b" />
